### PR TITLE
Bugfix/bpso 16019 infobar styling

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -9,7 +9,7 @@ $infobarBorder: 1px;
   align-items: center;
   height: $infobarHeight + $infobarBorder;
   box-sizing: border-box;
-  border-bottom: 1px solid $frost-color-lgrey-1;
+  border-bottom: $infobarBorder solid $frost-color-lgrey-1;
   background-color: $frost-color-white;
 
   .title {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -15,9 +15,9 @@
     line-height: 1.4;
 
     .primary-title {
-      font-size: $frost-font-xl;
-      color: $frost-color-night-1;
       margin-top: 25px;
+      font-size: $frost-font-m;
+      color: $frost-color-night-2;
     }
 
     .sub-title {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,38 +1,34 @@
 @import 'node_modules/ember-frost-core/addon/styles/frost-theme';
-$infobarHeight: 80px;
-$infobarBorder: 1px;
+$info-bar-height: 80px;
+$info-bar-border-width: 1px;
+$info-bar-padding-left-right: 30px;
+$info-bar-padding-top-bottom: 20px;
+$info-bar-title-margin-bottom: 8px;
 
 .frost-info-bar {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  height: $infobarHeight + $infobarBorder;
+  height: $info-bar-height + $info-bar-border-width;
   box-sizing: border-box;
-  border-bottom: $infobarBorder solid $frost-color-lgrey-1;
+  border-bottom: $info-bar-border-width solid $frost-color-lgrey-1;
   background-color: $frost-color-white;
+  padding: $info-bar-padding-top-bottom $info-bar-padding-left-right;
 
   .title {
-    margin-left: 30px;
     line-height: 1;
 
     .primary-title {
-      margin-top: 20px;
-      margin-bottom: 8px;
+      margin-bottom: $info-bar-title-margin-bottom;
       font-size: $frost-font-m;
       color: $frost-color-night-2;
     }
 
     .sub-title {
-      margin-bottom: 20px;
       font-size: $frost-font-s;
       color: $frost-color-grey-5;
     }
-  }
-
-  .action {
-    margin-left: auto;
-    margin-right: 30px;
   }
 }
 

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,21 +1,24 @@
 @import 'node_modules/ember-frost-core/addon/styles/frost-theme';
+$infobarHeight: 80px;
+$infobarBorder: 1px;
 
 .frost-info-bar {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-
+  height: $infobarHeight + $infobarBorder;
+  box-sizing: border-box;
   border-bottom: 1px solid $frost-color-lgrey-1;
-
   background-color: $frost-color-white;
 
   .title {
     margin-left: 30px;
-    line-height: 1.4;
+    line-height: 1;
 
     .primary-title {
-      margin-top: 25px;
+      margin-top: 20px;
+      margin-bottom: 8px;
       font-size: $frost-font-m;
       color: $frost-color-night-2;
     }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -22,7 +22,7 @@
 
     .sub-title {
       margin-bottom: 20px;
-      font-size: $frost-font-m;
+      font-size: $frost-font-s;
       color: $frost-color-grey-5;
     }
   }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -5,7 +5,6 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  height: 90px;
 
   border-bottom: 1px solid $frost-color-lgrey-1;
 
@@ -13,11 +12,12 @@
 
   .title {
     margin-left: 30px;
+    line-height: 1.4;
 
     .primary-title {
-      margin: 25px 0 10px 0;
       font-size: $frost-font-xl;
       color: $frost-color-night-1;
+      margin-top: 25px;
     }
 
     .sub-title {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -29,7 +29,7 @@
 
   .action {
     margin-left: auto;
-    margin-right: 20px;
+    margin-right: 30px;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "1.2.0",
     "ember-try": "^0.2.0",
-    "eslint": "2.2.0",
-    "eslint-config-frost-standard": "^1.0.0",
+    "eslint": "^2.9.0",
+    "eslint-config-frost-standard": "^2.0.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
this #PATCH# updates styling per spec + requested changes to spec:
title/sub-title font-size
sub-title color
info-bar padding/height
![info-bar-original](https://cloud.githubusercontent.com/assets/4720276/14961156/0ed0a888-104d-11e6-9589-2d9c8f4f2341.jpg)
![info-bar-with-changes](https://cloud.githubusercontent.com/assets/4720276/14961160/16a87b44-104d-11e6-97cc-b0a57122c42f.jpg)



