### PR TITLE
remove dummy app margin-left

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,9 +1,5 @@
 @import 'node_modules/ember-frost-core/addon/styles/frost-theme';
 
-.dummy-body{
-  margin-left: 20px;
-}
-
 .dummy-notification-container {
   position: fixed;
   top: 60px;


### PR DESCRIPTION
this #PATCH# removes dummy app margin-left
![info-bar-before-pr](https://cloud.githubusercontent.com/assets/4720276/14966097/91c3940e-1065-11e6-8d5e-b2f9b681e5ed.jpg)
![info-bar-no-dummy-margin](https://cloud.githubusercontent.com/assets/4720276/14966105/9e2ca17c-1065-11e6-81f8-74c98342e962.jpg)

