### PR TITLE
Update defining of class to use double quotes

### DIFF
--- a/addon/templates/components/frost-info-bar.hbs
+++ b/addon/templates/components/frost-info-bar.hbs
@@ -2,7 +2,7 @@
 
 <div class="title">
   {{#yield-slot 'title'}}
-      <div class='primary-title'>
+      <div class="primary-title">
         {{yield}}
       </div>
   {{/yield-slot}}
@@ -15,13 +15,13 @@
 </div>
 
 {{#yield-slot 'context-controls'}}
-    <div class='context-controls'>
+    <div class="context-controls">
       {{yield}}
     </div>
 {{/yield-slot}}
 
 {{#yield-slot 'actions'}}
-    <div class='action'>
+    <div class="action">
       {{yield (block-params (hash
         button=(component 'frost-button'
           priority='tertiary'


### PR DESCRIPTION
#patch#

Closes: https://github.com/ciena-frost/ember-frost-info-bar/issues/19

# CHANGELOG
* **Fixed** Usage of single quotes was updated to double quotes when setting a class in a div

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-info-bar/20)
<!-- Reviewable:end -->
