### PR TITLE
Info-bar API update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,31 @@ ember install ember-frost-info-bar
 ### Template
 ```handlebars
 {{frost-info-bar
-  icon-module=(component 'frost-icon'
+  icon=(component 'frost-icon'
+    isVisible=isIconVisible
     icon='bacon'
     pack='dummy'
   )
-  title-module=(component 'text-box'
+  title=(component 'text-box'
+    isVisible=isTitleVisible
     text='&lt;placeholder: title&gt;'
   )
-  summary-module=(component 'text-box'
-    isVisible=summary
+  summary=(component 'text-box'
+    isVisible=isSummaryVisible
     text='&lt;placeholder: summary&gt;'
   )
-  controls-module=(component 'text-box'
+  scope=(component 'text-box'
+    isVisible=isScopeVisible
     text='&lt;placeholder: controls&gt;'
   )
-  actions-module=(component 'frost-button'
-    design='info-bar'
-    icon='infobar-create'
-    text='Click me!'
-    onClick=(action 'triggerAction')
+  controls=(array
+    (component 'frost-button'
+      isVisible=isControlsVisible
+      design='info-bar'
+      icon='infobar-create'
+      text='Click me!'
+      onClick=(action 'triggerAction')
+    )
   )
 }}
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ ember install ember-frost-info-bar
   controls=(array
     (component 'frost-button'
       isVisible=isControlsVisible
-      design='info-bar'
       icon='infobar-create'
       text='Click me!'
       onClick=(action 'triggerAction')
@@ -54,6 +53,7 @@ The info-bar component is accessible using ember-hook with the top level hook na
 * Title slot hook - `$hook('<hook-name>-title')`
 * Summary slot hook - `$hook('<hook-name>-summary')'`
 * Controls slot hook - `$hook('<hook-name>-controls')'`
+* Controls slot item hook - `$hook('<hook-name>-controls-<index>')'`
 * Actions slot - `$hook('<hook-name>-action')'`
 
 ## Development

--- a/addon/helpers/array.js
+++ b/addon/helpers/array.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function array(params/*, hash*/) {
+  return params;
+}
+
+export default Ember.Helper.helper(array);

--- a/addon/helpers/array.js
+++ b/addon/helpers/array.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
-export function array(params/*, hash*/) {
-  return params;
+export function array (params/*, hash*/) {
+  return params
 }
 
-export default Ember.Helper.helper(array);
+export default Ember.Helper.helper(array)

--- a/addon/helpers/type-of.js
+++ b/addon/helpers/type-of.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+const {
+  Logger: {
+    error
+  }
+} = Ember
+
+export function typeOf(params/*, hash*/) {
+  if (params.length !== 2)  { error(`type-of helper expects 2 arguments, received ${params.length}`)}
+  const tester = params[0]
+  const type = params[1]
+  return typeof tester === type;
+}
+
+export default Ember.Helper.helper(typeOf);

--- a/addon/helpers/type-of.js
+++ b/addon/helpers/type-of.js
@@ -1,15 +1,15 @@
-import Ember from 'ember';
+import Ember from 'ember'
 const {
   Logger: {
     error
   }
 } = Ember
 
-export function typeOf(params/*, hash*/) {
-  if (params.length !== 2)  { error(`type-of helper expects 2 arguments, received ${params.length}`)}
+export function typeOf (params/*, hash*/) {
+  if (params.length !== 2) { error(`type-of helper expects 2 arguments, received ${params.length}`) }
   const tester = params[0]
   const type = params[1]
-  return typeof tester === type;
+  return typeof tester === type
 }
 
-export default Ember.Helper.helper(typeOf);
+export default Ember.Helper.helper(typeOf)

--- a/addon/templates/components/frost-info-bar.hbs
+++ b/addon/templates/components/frost-info-bar.hbs
@@ -1,7 +1,9 @@
 <!-- Icon -->
-<div class='frost-info-bar-icon' data-test={{hook (concat hook '-icon')}}>
-  {{component icon}}
-</div>
+{{#if icon}}
+    <div class='frost-info-bar-icon' data-test={{hook (concat hook '-icon')}}>
+      {{component icon}}
+    </div>
+{{/if}}
 <!-- Title -->
 <div class='title'>
   <div class='primary-title' data-test={{hook (concat hook '-title')}}>
@@ -11,25 +13,30 @@
         {{title}}
       {{/if}}
   </div>
-  <div class='sub-title' data-test={{hook (concat hook '-summary')}}>
-    {{#if (type-of summary 'object')}}
-      {{component summary}}
-    {{else}}
-      {{summary}}
-    {{/if}}
-  </div>
+  {{#if summary}}
+      <div class='sub-title' data-test={{hook (concat hook '-summary')}}>
+        {{#if (type-of summary 'object')}}
+          {{component summary}}
+        {{else}}
+          {{summary}}
+        {{/if}}
+      </div>
+  {{/if}}
 </div>
 <!-- Controls -->
-<div class='scope' data-test={{hook (concat hook '-scope')}}>
-  {{component scope}}
-</div>
+{{#if scope}}
+    <div class='scope' data-test={{hook (concat hook '-scope')}}>
+      {{component scope}}
+    </div>
+{{/if}}
+
 <!-- Actions -->
-<div class='controls' data-test={{hook (concat hook '-controls')}}>
+{{#if controls}}
+  <div class='controls' data-test={{hook (concat hook '-controls')}}>
     {{#each controls as |control index|}}
       {{component control
         design='info-bar'
-        hook=(concat hook '-controls-' index)
       }}
     {{/each}}
-</div>
-{{yield}}
+  </div>
+{{/if}}

--- a/addon/templates/components/frost-info-bar.hbs
+++ b/addon/templates/components/frost-info-bar.hbs
@@ -25,8 +25,11 @@
 </div>
 <!-- Actions -->
 <div class='controls' data-test={{hook (concat hook '-controls')}}>
-    {{#each controls as |control|}}
-      {{component control}}
+    {{#each controls as |control index|}}
+      {{component control
+        design='info-bar'
+        hook=(concat hook '-controls-' index)
+      }}
     {{/each}}
 </div>
 {{yield}}

--- a/addon/templates/components/frost-info-bar.hbs
+++ b/addon/templates/components/frost-info-bar.hbs
@@ -5,10 +5,18 @@
 <!-- Title -->
 <div class='title'>
   <div class='primary-title' data-test={{hook (concat hook '-title')}}>
-    {{component title}}
+      {{#if (type-of title 'object')}}
+        {{component title}}
+      {{else}}
+        {{title}}
+      {{/if}}
   </div>
   <div class='sub-title' data-test={{hook (concat hook '-summary')}}>
-    {{component summary}}
+    {{#if (type-of summary 'object')}}
+      {{component summary}}
+    {{else}}
+      {{summary}}
+    {{/if}}
   </div>
 </div>
 <!-- Controls -->
@@ -17,6 +25,8 @@
 </div>
 <!-- Actions -->
 <div class='controls' data-test={{hook (concat hook '-controls')}}>
-  {{component controls}}
+    {{#each controls as |control|}}
+      {{component control}}
+    {{/each}}
 </div>
 {{yield}}

--- a/app/helpers/array.js
+++ b/app/helpers/array.js
@@ -1,1 +1,1 @@
-export { default, array } from 'ember-frost-info-bar/helpers/array';
+export { default, array } from 'ember-frost-info-bar/helpers/array'

--- a/app/helpers/array.js
+++ b/app/helpers/array.js
@@ -1,0 +1,1 @@
+export { default, array } from 'ember-frost-info-bar/helpers/array';

--- a/app/helpers/type-of.js
+++ b/app/helpers/type-of.js
@@ -1,0 +1,1 @@
+export { default, typeOf } from 'ember-frost-info-bar/helpers/type-of';

--- a/app/helpers/type-of.js
+++ b/app/helpers/type-of.js
@@ -1,1 +1,1 @@
-export { default, typeOf } from 'ember-frost-info-bar/helpers/type-of';
+export { default, typeOf } from 'ember-frost-info-bar/helpers/type-of'

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -17,14 +17,17 @@
     isVisible=isScopeVisible
     text='&lt;placeholder: controls&gt;'
   )
-  controls=(component 'frost-button'
-    isVisible=isControlsVisible
-    design='info-bar'
-    icon='infobar-create'
-    text='Click me!'
-    onClick=(action 'triggerAction')
+  controls=(array
+    (component 'frost-button'
+      isVisible=isControlsVisible
+      design='info-bar'
+      icon='infobar-create'
+      text='Click me!'
+      onClick=(action 'triggerAction')
+    )
   )
 }}
+
 <!-- END-SNIPPET -->
 <div class='demo-controls'>
   {{frost-button

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -20,7 +20,6 @@
   controls=(array
     (component 'frost-button'
       isVisible=isControlsVisible
-      design='info-bar'
       icon='infobar-create'
       text='Click me!'
       onClick=(action 'triggerAction')

--- a/tests/integration/components/ember-frost-info-bar-test.js
+++ b/tests/integration/components/ember-frost-info-bar-test.js
@@ -30,6 +30,7 @@ const testTemplate = hbs`
     )
     controls=(array
       (component 'frost-button'
+        hook='create'
         isVisible=isControlsVisible
         icon='infobar-create'
         text='Click me!'
@@ -86,11 +87,11 @@ describeComponent(
     })
 
     it('has a hook for controls', function () {
-      const el = $hook('my-info-bar-controls-0')
+      const el = $hook('create')
       expect(text(el)).to.eql('Click me!')
     })
     it('triggers action correctly', function (done) {
-      const el = $hook('my-info-bar-controls-0')
+      const el = $hook('create')
       el.click()
       next(() => {
         expect(spy.called).to.be.true

--- a/tests/integration/components/ember-frost-info-bar-test.js
+++ b/tests/integration/components/ember-frost-info-bar-test.js
@@ -28,11 +28,13 @@ const testTemplate = hbs`
     scope=(component 'text-box'
       text='&lt;placeholder: scope&gt;'
     )
-    controls=(component 'frost-button'
-      design='info-bar'
-      icon='infobar-create'
-      text='Click me!'
-      onClick=(action 'triggerAction')
+    controls=(array
+      (component 'frost-button'
+        isVisible=isControlsVisible
+        icon='infobar-create'
+        text='Click me!'
+        onClick=(action 'triggerAction')
+      )
     )
   }}`
 
@@ -84,12 +86,12 @@ describeComponent(
     })
 
     it('has a hook for controls', function () {
-      const el = $hook('my-info-bar-controls')
+      const el = $hook('my-info-bar-controls-0')
       expect(text(el)).to.eql('Click me!')
     })
     it('triggers action correctly', function (done) {
-      const el = $hook('my-info-bar-controls')
-      el.find('button').click()
+      const el = $hook('my-info-bar-controls-0')
+      el.click()
       next(() => {
         expect(spy.called).to.be.true
         done()

--- a/tests/unit/helpers/array-test.js
+++ b/tests/unit/helpers/array-test.js
@@ -1,17 +1,17 @@
 /* jshint expr:true */
-import { expect } from 'chai';
+import { expect } from 'chai'
 import {
   describe,
   it
-} from 'mocha';
+} from 'mocha'
 import {
   array
-} from 'ember-frost-info-bar/helpers/array';
+} from 'ember-frost-info-bar/helpers/array'
 
-describe('ArrayHelper', function() {
+describe('ArrayHelper', function () {
   // Replace this with your real tests.
-  it('works', function() {
-    let result = array(42);
-    expect(result).to.be.ok;
-  });
-});
+  it('works', function () {
+    let result = array(42)
+    expect(result).to.be.ok
+  })
+})

--- a/tests/unit/helpers/array-test.js
+++ b/tests/unit/helpers/array-test.js
@@ -1,0 +1,17 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describe,
+  it
+} from 'mocha';
+import {
+  array
+} from 'ember-frost-info-bar/helpers/array';
+
+describe('ArrayHelper', function() {
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = array(42);
+    expect(result).to.be.ok;
+  });
+});

--- a/tests/unit/helpers/type-of-test.js
+++ b/tests/unit/helpers/type-of-test.js
@@ -1,17 +1,19 @@
 /* jshint expr:true */
-import { expect } from 'chai';
+import { expect } from 'chai'
 import {
   describe,
   it
-} from 'mocha';
+} from 'mocha'
 import {
   typeOf
-} from 'ember-frost-info-bar/helpers/type-of';
+} from 'ember-frost-info-bar/helpers/type-of'
 
-describe('TypeOfHelper', function() {
+describe('TypeOfHelper', function () {
   // Replace this with your real tests.
-  it('works', function() {
-    let result = typeOf(42);
-    expect(result).to.be.ok;
-  });
-});
+  it('works', function () {
+    const tester = {}
+    const type = 'object'
+    const result = typeOf([tester, type])
+    expect(result).to.be.ok
+  })
+})

--- a/tests/unit/helpers/type-of-test.js
+++ b/tests/unit/helpers/type-of-test.js
@@ -1,0 +1,17 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describe,
+  it
+} from 'mocha';
+import {
+  typeOf
+} from 'ember-frost-info-bar/helpers/type-of';
+
+describe('TypeOfHelper', function() {
+  // Replace this with your real tests.
+  it('works', function() {
+    let result = typeOf(42);
+    expect(result).to.be.ok;
+  });
+});


### PR DESCRIPTION
This is a #major# change.

# CHANGELOG

* **Updated** interface, now `controls` will take an array of components.
* **Updated** interface, now `title` and `summary` will take either component or string.
* **Added** `array` helper and `type-of` helper


