### PR TITLE
Added test for validating that mixin is present

### DIFF
--- a/tests/unit/components/info-bar-test.js
+++ b/tests/unit/components/info-bar-test.js
@@ -2,6 +2,7 @@ const expect = chai.expect
 
 import {describeComponent} from 'ember-mocha'
 import {beforeEach, it} from 'mocha'
+import PropTypeMixin from 'ember-prop-types'
 
 describeComponent(
   'frost-info-bar',
@@ -25,6 +26,13 @@ describeComponent(
         component.get('hook'),
         'hook is set to a default'
       ).to.eql('info-bar')
+    })
+
+    it('has the expected Mixins', function () {
+      expect(
+        PropTypeMixin.detect(component),
+        'PropTypeMixin Mixin is present'
+      ).to.be.true
     })
   }
 )


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
- **Added** test to verify mixin is present
