### PR TITLE
Fix naming of icon pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
     "configPath": "tests/dummy/config"
   },
   "ember-frost-icon-pack": {
-    "name": "info-bar"
+    "name": "frost-info-bar"
   }
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Fix naming of icon pack
