### PR TITLE
Extend frost component to get proper spread and hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ember install ember-frost-info-bar
 ### Template
 ```handlebars
 {{frost-info-bar
+  hook='info-bar'
   icon=(component 'frost-icon'
     hook='baconIcon'
     isVisible=isIconVisible

--- a/addon/components/frost-info-bar.js
+++ b/addon/components/frost-info-bar.js
@@ -1,6 +1,4 @@
 import {Component} from 'ember-frost-core'
-import PropTypeMixin, {PropTypes} from 'ember-prop-types'
-import SpreadMixin from 'ember-spread'
 import layout from '../templates/components/frost-info-bar'
 
 export default Component.extend({

--- a/addon/components/frost-info-bar.js
+++ b/addon/components/frost-info-bar.js
@@ -1,25 +1,11 @@
-import Ember from 'ember'
+import {Component} from 'ember-frost-core'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+import SpreadMixin from 'ember-spread'
 import layout from '../templates/components/frost-info-bar'
 
-const {
-  Component
-} = Ember
-
-export default Component.extend(PropTypeMixin, {
+export default Component.extend({
   // == Properties ============================================================
 
   classNames: ['frost-info-bar'],
-  layout,
-
-  // == State Properties ============================================================
-
-  propTypes: {
-    hook: PropTypes.string
-  },
-  getDefaultProps () {
-    return {
-      hook: 'info-bar'
-    }
-  }
+  layout
 })

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -53,13 +53,13 @@ $info-bar-title-separator: 5px;
     }
   }
 
-  .scope {
+  .frost-info-bar-scope {
     display: flex;
     flex: 1;
     justify-content: center;
   }
 
-  .controls {
+  .frost-info-bar-controls {
     margin-left: auto;
   }
 }

--- a/addon/templates/components/frost-info-bar.hbs
+++ b/addon/templates/components/frost-info-bar.hbs
@@ -27,14 +27,14 @@
 </div>
 <!-- Controls -->
 {{#if scope}}
-    <div class='scope' data-test={{hook (concat hook '-scope')}}>
+    <div class='frost-info-bar-scope' data-test={{hook (concat hook '-scope')}}>
       {{component scope}}
     </div>
 {{/if}}
 
 <!-- Actions -->
 {{#if controls}}
-  <div class='controls' data-test={{hook (concat hook '-controls')}}>
+  <div class='frost-info-bar-controls' data-test={{hook (concat hook '-controls')}}>
     {{#each controls as |control|}}
       {{component control
         design='info-bar'

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -1,5 +1,6 @@
 <!-- BEGIN-SNIPPET template -->
 {{frost-info-bar
+  hook='info-bar'
   icon=(component 'frost-icon'
     hook='findIcon'
     isVisible=isIconVisible

--- a/tests/index.html
+++ b/tests/index.html
@@ -26,7 +26,6 @@
     <script src="{{rootURL}}assets/dummy.js"></script>
     <script src="{{rootURL}}testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/tests.js"></script>
-    <script src="{{rootURL}}assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}
     {{content-for 'test-body-footer'}}

--- a/tests/integration/components/ember-frost-info-bar-test.js
+++ b/tests/integration/components/ember-frost-info-bar-test.js
@@ -57,7 +57,7 @@ describeComponent(
 
     it('has a default hook name', function () {
       this.render(hbs`
-        {{frost-info-bar}}
+        {{frost-info-bar hook='info-bar'}}
       `)
 
       expect(
@@ -72,6 +72,7 @@ describeComponent(
 
         this.render(hbs`
         {{frost-info-bar
+          hook='info-bar'
           icon=(component 'mock-icon' class='mock-icon')
         }}
       `)
@@ -94,6 +95,7 @@ describeComponent(
 
         this.render(hbs`
         {{frost-info-bar
+          hook='info-bar'
           icon=(component 'mock-icon')
         }}
       `)
@@ -111,6 +113,7 @@ describeComponent(
       it('sets the title hook', function () {
         this.render(hbs`
           {{frost-info-bar
+            hook='info-bar'
             title='My Test Title'
           }}
         `)
@@ -126,6 +129,7 @@ describeComponent(
 
         this.render(hbs`
           {{frost-info-bar
+            hook='info-bar'
             title=(component 'mock-title' class='mock-title')
           }}
         `)
@@ -141,6 +145,7 @@ describeComponent(
       it('renders the text if it is passed in', function () {
         this.render(hbs`
           {{frost-info-bar
+            hook='info-bar'
             title='My Test Title'
           }}
         `)
@@ -156,6 +161,7 @@ describeComponent(
           registerMockComponent(this, 'mock-summary')
           this.render(hbs`
             {{frost-info-bar
+              hook='info-bar'
               summary=(component 'mock-summary')
             }}
           `)
@@ -173,6 +179,7 @@ describeComponent(
 
           this.render(hbs`
             {{frost-info-bar
+              hook='info-bar'
               summary=(component 'mock-summary' class='mock-summary')
             }}
           `)
@@ -188,6 +195,7 @@ describeComponent(
         it('renders the text if it is passed in', function () {
           this.render(hbs`
             {{frost-info-bar
+              hook='info-bar'
               summary='My Test Summary'
             }}
           `)
@@ -205,12 +213,13 @@ describeComponent(
         registerMockComponent(this, 'mock-scope')
         this.render(hbs`
           {{frost-info-bar
+            hook='info-bar'
             scope=(component 'mock-scope')
           }}
         `)
 
         expect(
-          this.$($hook('info-bar-scope')).hasClass('scope'),
+          this.$($hook('info-bar-scope')).hasClass('frost-info-bar-scope'),
           'scope hook is set'
         ).to.equal(true)
 
@@ -222,6 +231,7 @@ describeComponent(
 
         this.render(hbs`
           {{frost-info-bar
+            hook='info-bar'
             scope=(component 'mock-scope' class='mock-scope')
           }}
         `)
@@ -241,12 +251,13 @@ describeComponent(
 
         this.render(hbs`
           {{frost-info-bar
+            hook='info-bar'
             controls=(array (component 'mock-control'))
           }}
         `)
 
         expect(
-          this.$($hook('info-bar-controls')).hasClass('controls'),
+          this.$($hook('info-bar-controls')).hasClass('frost-info-bar-controls'),
           'controls hook is set'
         ).to.equal(true)
 
@@ -258,6 +269,7 @@ describeComponent(
 
         this.render(hbs`
           {{frost-info-bar
+            hook='info-bar'
             controls=(array (component 'mock-control' class='mock-control'))
           }}
         `)

--- a/tests/unit/components/info-bar-test.js
+++ b/tests/unit/components/info-bar-test.js
@@ -14,7 +14,9 @@ describeComponent(
     let component
 
     beforeEach(function () {
-      component = this.subject()
+      component = this.subject({
+        hook: 'info-bar'
+      })
     })
 
     it('includes className frost-info-bar', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** class names to use prefix `frost-info-bar-` so they don't have collisions with other components not using scoped class names.
* **Updated** component to extend component from `ember-frost-core` so we have standard hook and spread support for a Frost component.
