### PR TITLE
Backward Compatability: add default hook 'info-bar'

### DIFF
--- a/addon/components/frost-info-bar.js
+++ b/addon/components/frost-info-bar.js
@@ -5,5 +5,6 @@ export default Component.extend({
   // == Properties ============================================================
 
   classNames: ['frost-info-bar'],
-  layout
+  layout,
+  hook: 'info-bar'
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Fix backwards compatibility issue with ember-hook by adding default hook `'info-bar'`. Where it was required consumers had to specify the hook `{{frost-info-bar hook='info-bar' ...`. Previously most consumers relied upon that hook being there, thus installing later versions of `ember-frost-info-bar` causes tests that rely on the hook to fail.
