### PR TITLE
Upgrade ember-cli to 2.12.3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": ["frost-standard"],
-  "globals": {
-      "capture": false
-  }
-}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: 'frost-standard',
+  globals: {
+    capture: false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,7 +13,7 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log
 coverage.json
 teamcity.txt

--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@
 .editorconfig
 .ember-cli
 .eslintignore
-.eslintrc
+.eslintrc.js
 .github
 .gitignore
 .pullapprove.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-release
+  - node_js: 'stable'
 
 before_install:
 - npm config set spin false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ cache:
 
 env:
   matrix:
-  - EMBER_TRY_SCENARIO=ember-2-8
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-lts-2.8
+    - EMBER_TRY_SCENARIO=ember-default
   global:
     - CXX=g++-4.8
     - secure: JRujOTzYLdFYpcrUAqoooJmL/h/B/o8Kh5OiTWh2wx60mphvYKnAL/S2k2Hx6d9ojnkBs7qM6AggE8OzxCcbfXhl+QOUZuOpJO38P+q9GMmzC1e8GOxvG9Wpmoa2qYk390ld3FDNydii4yAJZ6Qq73HOc/iRB4pgNMe++h4yC3uoh5/tgOCUzpW95PsHTCVwdQvoivNsIenlzawBYJOschTVFe79ZgMNn7dZotlLrDAq92K5DqVHvu7f1v8Xhdi5GI7S2aGapU64IXaE3IW76UgdECh1n1/53R9UmTCM2OtaRIn5WxUb6p4l6xVXIVe5BjBdaKzP1TGl1ZaKjivtJ/PC66xu08YCtOtYS5lrOintIWmqtW9sjQZvKRvq5fw5RwjYPHLN5EGGsUkMVBcY9voi5AoT4ueOTKabJLLOksQLBrsVgffkRyW57dy+MsQLo9s+RbFx5NWe8oV4VVIsuF25gCvBWbYtquAnavdvUWWerXnhoSx/EeOXvzCbee4m47+7+drPZAbL7G3hFl2IpgvKmxCeEWy9y9/ZEB0kNwwswTJnwE0RtpeVIqYKd5dW8lxhzLJemWD64KBMBObmucnjHrNj7kifX0siZ7oOMdZRbYp0m9eku/tU7qjKH2xo+XRW5TBxAR68XTF+LVMDPAGKYJr3/8nEno3y61gH4b8=
@@ -63,7 +62,7 @@ deploy:
     secure: E0nPCA+enZ1eWNDN/kFtQ3OLHlp1DaloKD0S1735FXl2nNN+awmVvMX0rCR/9gBBLpHBoZ/CA9T4PcY0brl4uxHyyG80xKudP1kAZ7K+3QI67iW0B+OJFGbMMe/hyEoDf0mtsOaviSf2Gi8hSYs1Sk/ACLeuZlRPFgice4vscD++9LgSHiC0f9AgbtSLlWz1TkVIKZv4GX5TJyPY1bpCFoN7I3eGOvAyxF5uxwY2PuemMkS1GNVh7KFNYSZ3lq80umbH6kj1CzF1w2emDLYY3ozMLmRh38JGSSe0/uIeKTVDYUTD0Qylk5JRoViFxxn191pxD/25CNgy+EFbIjwfvHjnwM4wiLiyJErgXsa8M0XhYCGC0l/+LRbR5XxKYHy4WCxHwuMUhafYxoE9ezWjQhjPUuQKqGvR0hXbNpVab0UWwiyNT3AjDFYX096j2oWff/rboGJRqEUKUP7lY1pOt5sgHdR1TGEgZ9gBR587gwVlh42joomRF0UiI9LJ4a6QEJ9DXatdEmAUnfhtrvuk/FrUESLgY+bfSZotd0qTAaS7EYl7hq3yaL6fFZmIhAK2ZU9Qw9QM4MmBldjQZFsAksyovyFEVmy7OYiotRC6qo3wUMUXbAobsK7vlkVg8xNBvfQQAVsRCFZWL+2YijhudUsPKp77/U+0wkW0TFJWd7s=
   on:
     all_branches: true
-    condition: "$EMBER_TRY_SCENARIO = 'default'"
+    condition: "$EMBER_TRY_SCENARIO = 'ember-default'"
     node: '6.9.1'
     tags: true
 

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -6,7 +6,7 @@ then
   exit 0
 fi
 
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
 then
   echo "Skipping version bump for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
   exit 0

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -14,7 +14,7 @@ then
   exit 0
 fi
 
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
 then
   echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
   exit 0

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "ember-frost-info-bar",
   "dependencies": {
-    "ember": "~2.11.0",
-    "ember-cli-shims": "~0.1.1",
     "ember-mocha-adapter": "~0.3.1",
     "sinonjs": "1.17.1",
     "chai-jquery": "^2.0.1",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,140 +1,36 @@
+/* eslint-env node */
+
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-1-12',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.12.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.12.0'
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
-      name: 'ember-1-13',
+      name: 'ember-lts-2.12',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-12'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-12'
         }
-      }
-    },
-    {
-      name: 'ember-2-0',
-      bower: {
-        dependencies: {
-          'ember': '~2.0.0'
-        },
-        resolutions: {
-          'ember': '~2.0.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-1',
-      bower: {
-        dependencies: {
-          'ember': '~2.1.0'
-        },
-        resolutions: {
-          'ember': '~2.1.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-2',
-      bower: {
-        dependencies: {
-          'ember': '~2.2.0'
-        },
-        resolutions: {
-          'ember': '~2.2.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-3',
-      bower: {
-        dependencies: {
-          'ember': '~2.3.0'
-        },
-        resolutions: {
-          'ember': '~2.3.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-4',
-      bower: {
-        dependencies: {
-          'ember': '~2.4.0'
-        },
-        resolutions: {
-          'ember': '~2.4.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-5',
-      bower: {
-        dependencies: {
-          'ember': '~2.5.0'
-        },
-        resolutions: {
-          'ember': '~2.5.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-6',
-      bower: {
-        dependencies: {
-          'ember': '~2.6.0'
-        },
-        resolutions: {
-          'ember': '~2.6.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-7',
-      bower: {
-        dependencies: {
-          'ember': '~2.7.0'
-        },
-        resolutions: {
-          'ember': '~2.7.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-8',
-      bower: {
-        dependencies: {
-          'ember': '~2.8.0'
-        },
-        resolutions: {
-          'ember': '~2.8.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-9',
-      bower: {
-        dependencies: {
-          'ember': '~2.9.0'
-        },
-        resolutions: {
-          'ember': '~2.9.0'
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -147,6 +43,11 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -157,6 +58,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -169,6 +75,17 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 'use strict'
 
 module.exports = function (/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,5 +1,5 @@
-/* global require, module */
-var EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
+/* eslint-env node */
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
   var app = new EmberAddon(defaults, {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-/* globals module */
+/* eslint-env node */
 
 'use strict'
 
 module.exports = {
   name: 'ember-frost-info-bar',
 
-  init: function (app) {
+  init: function () {
     this.options = this.options || {}
     this.options.babel = this.options.babel || {}
     this.options.babel.optional = this.options.babel.optional || []

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "lint-all-the-things",
     "start": "ember server",
     "test": "npm run lint && npm run test-addon",
-    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test"
+    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=ember-default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-info-bar.git",
   "engines": {
@@ -28,44 +28,44 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "~2.11.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-cli": "2.12.3",
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars-inline-precompile": "0.3.6",
-    "ember-cli-inject-live-reload": "^1.6.1",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
     "ember-cli-notifications": "4.1.6",
-    "ember-cli-test-loader": "^1.1.1",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-visual-acceptance": "2.2.0",
     "ember-code-snippet": "^1.8.0",
     "ember-computed-decorators": "~0.3.0",
     "ember-concurrency": "0.7.19",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-elsewhere": "0.4.1",
-    "ember-export-application-global": "^1.1.1",
+    "ember-export-application-global": "^1.0.5",
     "ember-frost-core": "^1.7.5",
     "ember-frost-notifier": "^4.1.2",
     "ember-hook": "^1.4.1",
-    "ember-load-initializers": "0.6.3",
+    "ember-load-initializers": "^0.6.0",
     "ember-prop-types": "^3.0.0",
     "ember-resolver": "^2.1.1",
     "ember-sinon": "0.6.0",
+    "ember-source": "~2.12.0",
     "ember-spread": "^1.1.1",
     "ember-test-utils": "^1.10.3",
     "ember-truth-helpers": "^1.3.0",
-    "loader.js": "^4.1.0"
+    "loader.js": "^4.2.3"
   },
   "keywords": [
     "ember-addon",
     "frost"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^5.1.0",
     "ember-frost-core": "^1.14.3"
   },

--- a/testem.js
+++ b/testem.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 var Reporter = require('ember-test-utils/reporter')
 
 module.exports = {

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "globals": {
-    "chai": true,
-    "Ember": true,
-    "sinon": true
-  }
-}

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    embertest: true
+  }
+};

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -2,4 +2,4 @@ module.exports = {
   env: {
     embertest: true
   }
-};
+}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,11 +4,15 @@ module.exports = function (environment) {
     podModulePrefix: 'dummy/pods',
     environment: environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
     APP: {
@@ -33,7 +37,6 @@ module.exports = function (environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.rootURL = '/'
     ENV.locationType = 'none'
 
     // keep test console output quieter

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,16 +5,13 @@ import Application from '../../app'
 import config from '../../config/environment'
 
 export default function startApp (attrs) {
-  let application
-
   let attributes = merge({}, config.APP)
   attributes = merge(attributes, attrs) // use defaults, but you can override
 
-  run(() => {
-    application = Application.create(attributes)
+  return run(() => {
+    let application = Application.create(attributes)
     application.setupForTesting()
     application.injectTestHelpers()
+    return application
   })
-
-  return application
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,10 +21,10 @@
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>
-    <script src="{{rootURL}}testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for 'body-footer'}}

--- a/tests/unit/components/info-bar-test.js
+++ b/tests/unit/components/info-bar-test.js
@@ -1,5 +1,4 @@
-const expect = chai.expect
-
+import {expect} from 'chai'
 import PropTypeMixin from 'ember-prop-types'
 import {beforeEach, describe, it} from 'mocha'
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Upgrade `ember-cli` to `2.12.3`
