### PR TITLE
Upgrade ember-cli 2.12.3 inter-dependencies

### DIFF
--- a/blueprints/ember-frost-info-bar/index.js
+++ b/blueprints/ember-frost-info-bar/index.js
@@ -3,7 +3,7 @@ const blueprintHelper = require('ember-frost-core/blueprint-helper')
 module.exports = {
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '^1.14.3'}
+      {name: 'ember-frost-core', target: '1.23.10'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-frost-blueprints": "1.2.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
@@ -44,7 +45,7 @@
     "ember-computed-decorators": "~0.3.0",
     "ember-concurrency": "0.7.19",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-elsewhere": "0.4.1",
+    "ember-elsewhere": "1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-frost-core": "^1.7.5",
     "ember-frost-notifier": "^4.1.2",
@@ -66,8 +67,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-sass": "^5.1.0",
-    "ember-frost-core": "^1.14.3"
+    "ember-cli-sass": "5.6.0",
+    "ember-frost-core": "1.23.10"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Upgrade ember-cli 2.12.3 inter-dependencies