### PR TITLE
Change semver range of ember-resolver to align with other repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-hook": "^1.4.1",
     "ember-load-initializers": "^0.6.0",
     "ember-prop-types": "^5.0.1",
-    "ember-resolver": "^2.1.1",
+    "ember-resolver": "^2.0.3",
     "ember-sinon": "0.6.0",
     "ember-source": "~2.12.0",
     "ember-spread": "^3.0.0",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Change semver range of `ember-resolver` to align with other repos