### PR TITLE
tweaked spacing between title and summary

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -4,7 +4,7 @@ $info-bar-border-width: 1px;
 $info-bar-padding-left: 30px;
 $info-bar-padding-right: 0;
 $info-bar-padding-top-bottom: 20px;
-$info-bar-title-separator: 5px;
+$info-bar-title-separator: 10px;
 
 .frost-info-bar {
   display: flex;


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: #88 

![screen shot 2018-02-27 at 11 05 38 am](https://user-images.githubusercontent.com/26879720/36739776-c67c6b20-1bae-11e8-9bca-8cc66314d2e6.png)

gap between title and summary increased by 5 pixels

# CHANGELOG
**Changed** spacing between info bar title and sub-title
